### PR TITLE
Add SDSC_ISG-TrendModel

### DIFF
--- a/.github/workflows/automate_SDSC_ISG-TrendModel.yml
+++ b/.github/workflows/automate_SDSC_ISG-TrendModel.yml
@@ -1,0 +1,66 @@
+name: "SDSC_ISG-TrendModel"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 2 * * 1"
+
+jobs:
+  generate-forecasts:
+    runs-on: ubuntu-20.04
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+        
+    - uses: r-lib/actions/setup-r@v2
+      with:
+        use-public-rspm: true
+        
+    - uses: r-lib/actions/setup-renv@v2
+      
+    - name: Generate forecasts
+      working-directory: models/${{ github.workflow }}
+      run: |
+        renv::restore()
+        source("main.R")
+      shell: Rscript {0}
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.workflow }}
+        retention-days: 5
+        path: models/${{ github.workflow }}/data-processed/**/*
+
+  upload-forecasts:
+    needs: generate-forecasts
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v3
+      with: 
+        repository: 'covid19-forecast-hub-europe/covid19-forecast-hub-europe'
+        token: ${{ secrets.FORECASTHUB_TOKEN }}
+    
+    - uses: actions/download-artifact@v3
+      with:
+        name: ${{ github.workflow }}
+        path: data-processed
+        
+    - uses: peter-evans/create-pull-request@67df31e08a133c6a77008b89689677067fef169e
+      id: cpr
+      with:
+        token: ${{ secrets.FORECASTHUB_TOKEN }}
+        commit-message: ${{ github.workflow }}'s automated submission
+        committer: epiforecasts-bot <epiforecasts-bot@users.noreply.github.com>
+        author: epiforecasts-bot <epiforecasts-bot@users.noreply.github.com>
+        branch: ${{ github.workflow }}
+        title: ${{ github.workflow }}'s automated submission
+        body: Automated submission via https://github.com/epiforecasts/covid19-forecast-hub-europe-submissions
+        delete-branch: true
+
+    - name: Check outputs
+      run: |
+        echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+        echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/models/SDSC_ISG-TrendModel/main.R
+++ b/models/SDSC_ISG-TrendModel/main.R
@@ -1,0 +1,15 @@
+# Pull SDSC_ISG-TrendModel from repo
+
+forecast_date <- lubridate::floor_date(lubridate::today(),
+                               unit = "week",
+                               week_start = 7)
+
+filename <- paste0(forecast_date, "-SDSC_ISG-TrendModel.csv")
+
+url <- paste0("https://raw.githubusercontent.com/TaoSunVoyage/covid19-forecast-hub-europe/main/data-processed/SDSC_ISG-TrendModel/", filename)
+
+dir <- here::here("models", "SDSC_ISG-TrendModel", "data-processed")
+
+dir.create(dir)
+
+download.file(url = url, destfile = paste0(dir, "/", filename))


### PR DESCRIPTION
The forecast hub has weekly contributions from the SDSC_ISG-TrendModel, submitted by @TaoSunVoyage (thanks!). Unfortunately when it comes to submission there are weekly merge conflicts in the PRs. 

See [PRs to the hub](https://github.com/covid19-forecast-hub-europe/covid19-forecast-hub-europe/pulls?q=is%3Apr+SDSC_ISG-TrendModel) which have required either manual merge from main or a separate PR that cherry picks the individual forecast commit.

I've previously suggested this could be resolved by updating the [fork](https://github.com/TaoSunVoyage/covid19-forecast-hub-europe) to match the origin Hub repo. However I do not have write access to the fork to manage this. 

As an alternative, this PR fetches only the latest forecast file from the fork using the automated submissions system. This means weekly PRs will be created automatically and any PRs coming from the conflicted fork can be closed (without losing the forecast). This PR:
- creates a new model file, SDSC_ISG-TrendModel. This includes `main.R`, which
   - sets the forecast date used by the model
   - downloads the latest forecast into this repo: models/SDSC_ISG-TrendModel/data-processed
- adds a github action to automate submission. This is a modified copy of [automate_baseline.yml](https://github.com/covid19-forecast-hub-europe/covid19-forecast-hub-europe-submissions/blob/main/.github/workflows/automate_baseline.yml).
