### PR TITLE
run timeseries model on Mondays

### DIFF
--- a/.github/workflows/automate_epiforecasts-timeseries.yml
+++ b/.github/workflows/automate_epiforecasts-timeseries.yml
@@ -2,7 +2,7 @@ name: "epiforecasts-timeseries"
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 13 * * 2"
+    - cron: "0 13 * * 1"
 
 jobs:
   generate-forecasts:


### PR DESCRIPTION
At the moment the epiforecasts-timeseries model runs on Tuesdays 1pm. This is because historically it relied on the case ensemble which would have been created by then. However, it no longer uses this ensemble so this update is to run it on Mondays instead, so that it can be merged on Tuesdays alongside the other models.